### PR TITLE
Fix URL from HTTP to HTTPS

### DIFF
--- a/pages/u/favourite.vue
+++ b/pages/u/favourite.vue
@@ -83,7 +83,7 @@ export default {
   methods: {
 
     HeadSearchUp() {
-      return axios.get(`http://api.ixil.cc/bloom/strat/user/get/favs?page=${this.Page}&op=30&email=${this.$auth.user.email}`, {
+      return axios.get(`https://api.ixil.cc/bloom/strat/user/get/favs?page=${this.Page}&op=30&email=${this.$auth.user.email}`, {
         headers: {
           Authorization: this.$auth.getToken('auth0') //the token is a variable which holds the token
         }


### PR DESCRIPTION
fix:
```md
Mixed Content: The page at 'https://app.ixil.cc/u/favourite' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.ixil.cc/bloom/strat/user/get/favs?page=1&op=30&email=NULLED'. This request has been blocked; the content must be served over HTTPS.
```